### PR TITLE
Fix FlowMatchUniPC progress bar configuration

### DIFF
--- a/diffusers_helper/k_diffusion/uni_pc_fm.py
+++ b/diffusers_helper/k_diffusion/uni_pc_fm.py
@@ -4,11 +4,13 @@
 # Attribution-ShareAlike 4.0 International Licence
 
 
+import sys
+
 import torch
 
 from typing import Any, Dict, Optional
 
-from tqdm.auto import trange
+from tqdm import trange
 
 from framepack import flf_helpers
 
@@ -222,7 +224,13 @@ class FlowMatchUniPC:
     def sample(self, x, sigmas, callback=None, disable_pbar=False):
         order = min(3, len(sigmas) - 2)
         model_prev_list, t_prev_list = [], []
-        for i in trange(len(sigmas) - 1, disable=disable_pbar):
+        for i in trange(
+            len(sigmas) - 1,
+            disable=disable_pbar,
+            leave=True,
+            dynamic_ncols=True,
+            file=sys.stdout,
+        ):
             vec_t = sigmas[i].expand(x.shape[0])
 
             if i == 0:


### PR DESCRIPTION
## Summary
- import `trange` from `tqdm` and route the progress bar output to stdout to avoid auto-disabling in non-interactive environments
- configure the FlowMatchUniPC sampling loop to keep the progress bar visible by default while still respecting the `disable_pbar` flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db84d82c8c832e81e986dee0943682